### PR TITLE
Updating Timezone Library.

### DIFF
--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -36,7 +36,6 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "dayjs": "^1.10.5",
-    "timezone-support": "^2.0.2"
+    "dayjs": "^1.10.5"
   }
 }

--- a/packages/utilities/src/is-outside-business-hours.ts
+++ b/packages/utilities/src/is-outside-business-hours.ts
@@ -2,12 +2,14 @@ import dayjs from 'dayjs';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
-import { findTimeZone, getZonedTime } from 'timezone-support';
-import { formatZonedTime } from 'timezone-support/dist/parse-format';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 
 dayjs.extend(advancedFormat);
 dayjs.extend(relativeTime);
 dayjs.extend(localizedFormat);
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 type DateInput = Date | number;
 
@@ -53,11 +55,7 @@ const getWorkingHours = (data: string): string[][] => {
 const toTimeZone = (timeStamp: DateInput, preferredTimeZone: string): string => {
   if (timeStamp && preferredTimeZone) {
     try {
-      const timeZoneData = findTimeZone(preferredTimeZone);
-      const convertedTime = getZonedTime(timeStamp, timeZoneData);
-      const format = 'YYYY-MM-DD HH:mm:ss';
-
-      return formatZonedTime(convertedTime, format);
+      return dayjs(timeStamp).tz(preferredTimeZone).format('YYYY-MM-DD HH:mm:ss');
     } catch (err) {
       return '';
     }

--- a/packages/utilities/test/is-outside-business-hours.test.ts
+++ b/packages/utilities/test/is-outside-business-hours.test.ts
@@ -52,7 +52,24 @@ describe('Utils test', () => {
       };
       assert.equal(false, isOutsideBusinessHours(businessHour, agentTime));
     });
+    it('should return false when agent is within hours in Brazil/East',() =>{
+      businessHour.enabled = true;
+      // 11:29 AM in BST
+      businessHour.timezone = 'Brazil/East';
+      const agentTime = 1638887393000;
+      businessHour.working = {
+        '0': 'true',
+        '1': 'true',
+        '2': 'true',
+        '3': 'true',
+        '4': 'true',
+        '5': 'true',
+        '6': 'true',
+      };
+      assert.equal(false, isOutsideBusinessHours(businessHour, agentTime));
+    });
     it('should return true when agent is outside business hour but working on that week', () => {
+      businessHour.timezone='UTC';
       businessHour.enabled = true;
       // 01:10 PM in UTC
       const agentTime = 1586437800201;
@@ -77,6 +94,7 @@ describe('Utils test', () => {
       businessHour.enabled = true;
       assert.equal(true, isOutsideBusinessHours(businessHour, 0));
     });
+
     it('should return true when wrong timezone is passed', () => {
       businessHour.enabled = true;
       businessHour.timezone = 'test';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,11 +2519,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
-
 commander@^2.19.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -7832,13 +7827,6 @@ time-stamp@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
-
-timezone-support@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/timezone-support/-/timezone-support-2.0.2.tgz#801d6924478b1b60f09b90699ce1127a6044cbe7"
-  integrity sha512-J/1PyHCX76vOPuJzCyHMQMH2wTjXCJ30R5EXaS/QTi+xYsL0thS0pubDrHCWnfG4zU1jpPJtctnBBRCOpcJZeQ==
-  dependencies:
-    commander "2.20.0"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
The timezone support library has not been updated in 2 years because of which Brazil's decision to scrap DST is not reflected in our app.